### PR TITLE
Wip main

### DIFF
--- a/src/mingo/tests/test_api.py
+++ b/src/mingo/tests/test_api.py
@@ -3,7 +3,9 @@ from tempfile import gettempdir
 from platform import system
 from pathlib import Path
 from mingo.tests.mock_data import MOCK_SOURCE_DATA
-from mingo import *
+from mingo import (
+    Database, Hit_distribution, Shower_depth, Scattering, Plane_hits
+)
 import pandas as pd
 
 

--- a/src/mingo/tests/test_database.py
+++ b/src/mingo/tests/test_database.py
@@ -1,329 +1,362 @@
-from mingo import Database
-from typing import Union
 import pytest
-from sqlalchemy import Table, MetaData, select
-from mingo.tests.mock_data import (
-    MOCK_SOURCE_DATA, make_mock_database,
-    make_sources, make_mock_mingo
-)
+from pathlib import Path
+from platform import system
+from tempfile import gettempdir
+from mingo.tests.mock_data import MOCK_SOURCE_DATA
+from mingo import Database
+from sqlalchemy import MetaData, select
 
-EXPECTED_CONFIG = (1, 1, 2, 1, 3, 0, 100, 200, 400)
-EXPECTED_PLANE = [
-    (1, 999, 999, 22, 0, "0", 0),
-    (2, 999, 999, 22, 22, "Pb", 10.4),
-    (3, 999, 999, 22, 222, "Pb", 16.2)
+
+# ################################## NOTE ################################## #
+#                                                                            #
+#  These tests require the existance of a configuration file for MariaDB     #
+#  The absolute path to this file is stored in CONFIG_FILE, which defaults   #
+#  to '~/.my.cnf'. Update this variable with your own config file!           #
+#                                                                            #
+# ########################################################################## #
+
+
+CONFIG_FILE = "~/.my.cnf"
+EXPECTED_TABLES = ["config", "plane", "event", "hit"]
+EXPECTED_COLUMNS = {
+    "config": ["id", "fk_p1", "fk_p2",
+               "fk_p3", "fk_p4", "z_p1", "z_p2", "z_p3", "z_p4"],
+    "plane": ["id", "size_x",
+              "size_y", "size_z", "abs_z", "abs_mat", "abs_thick"],
+    "event": ["id", "fk_config", "particle", "e_0", "theta", "phi", "n_hits"],
+    "hit": ["id", "fk_event", "plane", "x", "y", "z", "t"]
+}
+EXPECTED_CONFIG = [
+    (1, 1, 2, 1, 3, 0, 100, 200, 400),
+    (2, 1, 4, 1, 5, 0, 100, 200, 400)
 ]
-EXPECTED_EVENT = (1, 1, "electron", 800, 0, 0, 24)
-EXPECTED_HIT = (24, 1, 2, 23.83, 3.95, 100, 0.3809)
+EXPECTED_PLANE = [
+    (999, 999, 22, 0, "0", 0),
+    (999, 999, 22, 22, "Pb", 10.4),
+    (999, 999, 22, 222, "Pb", 10.4),
+    (999, 999, 22, 22, "Pb", 16.2),
+    (999, 999, 22, 222, "Pb", 16.2)
+]
+EXPECTED_EVENT = [
+    ("electron", 800, 0, 0, 24),
+    ("electron", 1000, 0, 0, 63)
+]
+EXPECTED_HIT = [
+    (2, 23.83, 3.95, 100, 0.3809),
+    (2, -77.38, -26, 100.5, 0.583)
+]
+
+
+@pytest.fixture(scope="module")
+def make_sources():
+
+    tmp = Path("/tmp") if system() == "Darwin" else Path(gettempdir())
+
+    key_list = list(MOCK_SOURCE_DATA.keys())
+
+    sources: list[Path] = [
+        tmp / f"{key_list[0]}.txt", tmp / f"{key_list[-1]}.txt"
+    ]
+
+    sources[0].write_text(MOCK_SOURCE_DATA[key_list[0]])
+    sources[-1].write_text(MOCK_SOURCE_DATA[key_list[-1]])
+
+    # sources: list[Path] = [
+    #     tmp / f"{list(MOCK_SOURCE_DATA.keys())[0]}.txt",
+    #     tmp / f"{list(MOCK_SOURCE_DATA.keys())[-1]}.txt"
+    # ]
+
+    # for key, data in MOCK_SOURCE_DATA.items():
+    #     sources.append(tmp / f"{key}.txt")
+    #     sources[-1].write_text(data)
+
+    yield sources
+
+    for source in sources:
+        source.unlink()
+
+
+@pytest.fixture(scope="module")
+def make_database(make_sources: list[Path]):
+
+    db = Database("mock_database", cnf_path=CONFIG_FILE, ask_to_create=False)
+    sources = make_sources
+
+    for source in sources:
+        db.fill(source)
+
+    yield db
+
+    db.drop()
+
+
+def check_database_structure(db: Database) -> None:
+
+    # MetaData object exists and expected tables are present
+    assert isinstance(db.meta, MetaData)
+    assert list(db.meta.tables.keys()) == EXPECTED_TABLES
+
+    # Check for expected columns
+    assert list(db.config.c.keys()) == EXPECTED_COLUMNS["config"]
+    assert list(db.plane.c.keys()) == EXPECTED_COLUMNS["plane"]
+    assert list(db.event.c.keys()) == EXPECTED_COLUMNS["event"]
+    assert list(db.hit.c.keys()) == EXPECTED_COLUMNS["hit"]
+
+    return None
+
+
+def check_database_content(db: Database) -> None:
+
+    with db.engine.connect() as conn:
+
+        # Check data in config table
+        _data = conn.execute(select(db.config)).fetchall()
+        # Output is independent of input order, no need to re-arrange
+        _config_data = [_data[0], _data[-1]]
+        for idx, config_data in enumerate(_config_data):
+            assert config_data == EXPECTED_CONFIG[idx]
+            assert isinstance(config_data[0], int)
+            assert isinstance(config_data[1], int)
+            assert isinstance(config_data[2], int)
+            assert isinstance(config_data[3], int)
+            assert isinstance(config_data[4], int)
+            assert isinstance(config_data[5], float)
+            assert isinstance(config_data[6], float)
+            assert isinstance(config_data[7], float)
+            assert isinstance(config_data[8], float)
+
+        # Check data in plane table
+        planes_data = conn.execute(
+            select(db.plane)
+            .order_by(db.plane.c.abs_thick)
+            .order_by(db.plane.c.abs_z)
+        )
+
+        for idx, result in enumerate(planes_data):
+            # EXPECTED_PLANE does not include plane id -> result[1:]
+            assert EXPECTED_PLANE[idx] == result[1:]
+            assert isinstance(result[0], int)
+            assert isinstance(result[1], float)
+            assert isinstance(result[2], float)
+            assert isinstance(result[3], float)
+            assert isinstance(result[4], float)
+            assert isinstance(result[5], str)
+            assert isinstance(result[6], float)
+
+        # Check data in event table
+        _data = conn.execute(
+            select(db.event).order_by(db.event.c.e_0)).fetchall()
+        _event_data = [_data[0], _data[-1]]
+        for idx, event_data in enumerate(_event_data):
+            assert EXPECTED_EVENT[idx] == event_data[2:]
+            assert isinstance(event_data[0], int)
+            assert isinstance(event_data[1], int)
+            assert isinstance(event_data[2], str)
+            assert isinstance(event_data[3], float)
+            assert isinstance(event_data[4], float)
+            assert isinstance(event_data[5], float)
+            assert isinstance(event_data[6], int)
+
+        # Check data in hit table
+        _hit_data = [
+            conn.execute(
+                select(db.hit)
+                .where(db.hit.c.fk_event == _event_data[0][0])
+            ).fetchall()[-1],
+            conn.execute(
+                select(db.hit)
+                .where(db.hit.c.fk_event == _event_data[-1][0])
+            ).fetchall()[-1]
+        ]
+        for idx, hit_data in enumerate(_hit_data):
+            assert hit_data[2:] == EXPECTED_HIT[idx]
+            assert isinstance(hit_data[0], int)
+            assert isinstance(hit_data[1], int)
+            assert isinstance(hit_data[2], int)
+            assert isinstance(hit_data[3], float)
+            assert isinstance(hit_data[4], float)
+            assert isinstance(hit_data[5], float)
+            assert isinstance(hit_data[6], float)
+
+    return None
+
+
+def test_Database_create() -> None:
+    """Create an empty database"""
+
+    db = Database("mock_database", cnf_path=CONFIG_FILE, ask_to_create=False)
+
+    try:
+        check_database_structure(db)
+    finally:
+        db.drop()
+
+    return None
+
+
+def test_Database_load() -> None:
+    """Load empty database and check structure"""
+
+    _db = Database("mock_database", cnf_path=CONFIG_FILE, ask_to_create=False)
+    db = Database(_db.engine.url.database, cnf_path=CONFIG_FILE)
+
+    try:
+        check_database_structure(db)
+    finally:
+        db.drop()
+
+    return None
 
 
 @pytest.mark.parametrize(
+    "input_format",
     [
-        "use_cnf", "cnf_path", "drivername", "username", "password", "host",
-        "port", "database"
-    ],
-    [
-        (True, "~/.my.cnf", "mariadb+mysqldb", None, None, None, None, None),
-        (True, "not-found", "mariadb+mysqldb", None, None, None, None, None)
+        "str-file path-file", "str-dir", "path-dir",
+        "[str-file, str-file]", "(str-file, str-file)",
+        "[path-file, path-file]", "(path-file, path-file)",
+        "[str-file, path-file]", "(str-file, path-file)"
     ]
 )
-def test_create_engine(
-        use_cnf: bool,
-        cnf_path: str,
-        drivername: str,
-        username: Union[str, None],
-        password: Union[str, None],
-        host: Union[str, None],
-        port: Union[int, None],
-        database: Union[str, None]
-) -> None:
+def test_Database_fill(make_sources: list[Path], input_format: str) -> None:
+    """
+    Create an empty database, fill it with two data-files using different
+    input formats and check for expected content. Then load the database 
+    into a new Database object and repeat tests to ensure that loading does
+    not affect content or data types for any input format.
+    """
 
-    # TODO: Handle errors due to missing driver or cnf file
-    # TODO: Handle errors due to incorrect username, password, port or host
+    sources = make_sources
+    source_A = sources[0]
+    source_B = sources[-1]
+
+    db = Database("mock_database", ask_to_create=False)
+
+    try:
+        match input_format:
+            case "str-file path-file":
+                db.fill(str(source_A))
+                db.fill(source_B)
+            case "str-dir":
+                db.fill(str(source_A.parent))
+            case "path-dir":
+                db.fill(source_A.parent)
+            case "[str-file, str-file]":
+                db.fill([str(source_A), str(source_B)])
+            case "(str-file, str-file)":
+                db.fill((str(source_A), str(source_B)))
+            case "[path-file, path-file]":
+                db.fill([source_A, source_B])
+            case "(path-file, path-file)":
+                db.fill((source_A, source_B))
+            case "[str-file, path-file]":
+                db.fill([str(source_A), source_B])
+            case "(str-file, path-file)":
+                db.fill((str(source_A), source_B))
+            case _:
+                raise ValueError("Unexpected input format")
+
+        # Perform tests on filled database
+        check_database_content(db)
+
+        # Repeat tests on loaded database
+        # No need to set ask_to_create = False if database is loaded
+        loaded_db = Database(db.engine.url.database)
+        check_database_content(loaded_db)
+
+    finally:
+        db.drop()
 
     return None
 
 
-def test_create_database(make_mock_database: Database) -> None:
-    """
-    Ensure that an unexisting database is properly created
-    """
+def test_plane_id_uniqueness() -> None:
+    """Ensure uniqueness and continuity of plane IDs"""
 
-    db = make_mock_database
+    db = Database("mock_database", ask_to_create=False)
 
-    # MetaData object exists and all tables are present
-    assert isinstance(db.meta, MetaData)
-    table_list = [table for table in db.meta.tables.keys()]
-    assert table_list == ["config", "plane", "event", "hit"]
+    try:
+        planes = [
+            (None, 0, 0, 0, 0, "0", 0),
+            (None, 1, 0, 0, 0, "0", 0),
+            (None, 2, 0, 0, 0, "0", 0),
+            (None, 3, 0, 0, 0, "0", 0),
+            (None, 4, 0, 0, 0, "0", 0),
+            (None, 5, 0, 0, 0, "0", 0)
+        ]
 
-    # All tables are instances of Table
-    assert isinstance(db.config, Table)
-    assert isinstance(db.plane, Table)
-    assert isinstance(db.event, Table)
-    assert isinstance(db.hit, Table)
+        expected_plane_data = [
+            (1, 0, 0, 0, 0, "0", 0),
+            (2, 1, 0, 0, 0, "0", 0),
+            (3, 2, 0, 0, 0, "0", 0),
+            (4, 3, 0, 0, 0, "0", 0),
+            (5, 4, 0, 0, 0, "0", 0)
+        ]
 
-    # Each table has the expected number of columns
-    assert len(db.config.c.keys()) == 9
-    assert len(db.plane.c.keys()) == 7
-    assert len(db.event.c.keys()) == 7
-    assert len(db.hit.c.keys()) == 7
+        # Test single inserts: u(nique) + d(uplicate) + u
+        first, = db.insert_plane(planes[0])
+        second, = db.insert_plane(planes[0])
+        third, = db.insert_plane(planes[1])
+        assert first == expected_plane_data[0]
+        assert second == first
+        assert third == expected_plane_data[1]
 
-    return None
-
-
-def test_load_database(make_mock_database: Database) -> None:
-    """
-    Ensure that an existing database is properly loaded
-    """
-
-    mock_db = make_mock_database
-
-    db = Database(mock_db.engine.url.database, True)
-
-    # MetaData object exists and all tables are present
-    assert isinstance(db.meta, MetaData)
-    table_list = [table for table in db.meta.tables.keys()]
-    assert table_list == ["config", "plane", "event", "hit"]
-
-    # All tables are instances of Table
-    assert isinstance(db.config, Table)
-    assert isinstance(db.plane, Table)
-    assert isinstance(db.event, Table)
-    assert isinstance(db.hit, Table)
-
-    # Each table has the expected number of columns
-    assert len(db.config.c.keys()) == 9
-    assert len(db.plane.c.keys()) == 7
-    assert len(db.event.c.keys()) == 7
-    assert len(db.hit.c.keys()) == 7
+        # Test batch insert: [u, d, u] + u
+        fourth = db.insert_plane([planes[2], planes[2], planes[3]])
+        fifth, = db.insert_plane(planes[4])
+        assert fourth[0] == expected_plane_data[2]
+        assert fourth[1] == expected_plane_data[2]
+        assert fourth[2] == expected_plane_data[3]
+        assert fifth == expected_plane_data[4]
+    finally:
+        db.drop()
 
     return None
 
 
-def test_fill_database(make_mock_database: Database) -> None:
-    """
-    Ensure that the database is properly filled and data is not corrupted
-    """
+def test_config_id_uniqueness() -> None:
+    """Ensure uniqueness and continuity of config IDs"""
 
-    _source = make_sources("10-16-800.txt", MOCK_SOURCE_DATA["10-16-800"])
-    source = next(_source)
+    db = Database("mock_database", ask_to_create=False)
 
-    db = make_mock_database
-    db.fill(source)
+    try:
+        planes = [(None, 0, 0, 0, 0, "0", 0), (None, 1, 0, 0, 0, "0", 0)]
+        db.insert_plane(planes)
 
-    with db.engine.connect() as conn:
+        configs = [
+            (None, 1, 1, 1, 1, 0, 0, 0, 0),
+            (None, 1, 1, 1, 2, 0, 0, 0, 0),
+            (None, 1, 1, 2, 1, 0, 0, 0, 0),
+            (None, 1, 2, 1, 1, 0, 0, 0, 0),
+            (None, 2, 1, 1, 1, 0, 0, 0, 0)
+        ]
 
-        # Check data in config table
-        config_data, = conn.execute(select(db.config))
-        assert config_data == EXPECTED_CONFIG
-        assert isinstance(config_data[0], int)
-        assert isinstance(config_data[1], int)
-        assert isinstance(config_data[2], int)
-        assert isinstance(config_data[3], int)
-        assert isinstance(config_data[4], int)
-        assert isinstance(config_data[5], float)
-        assert isinstance(config_data[6], float)
-        assert isinstance(config_data[7], float)
-        assert isinstance(config_data[8], float)
+        expected_result = [
+            (1, 1, 1, 1, 1, 0, 0, 0, 0),
+            (2, 1, 1, 1, 2, 0, 0, 0, 0),
+            (3, 1, 1, 2, 1, 0, 0, 0, 0),
+            (4, 1, 2, 1, 1, 0, 0, 0, 0),
+            (5, 2, 1, 1, 1, 0, 0, 0, 0)
 
-        # Check data in plane table
-        planes_data = conn.execute(select(db.plane))
+        ]
 
-        for idx, result in enumerate(planes_data):
-            assert EXPECTED_PLANE[idx] == result
-            assert isinstance(result[0], int)
-            assert isinstance(result[1], float)
-            assert isinstance(result[2], float)
-            assert isinstance(result[3], float)
-            assert isinstance(result[4], float)
-            assert isinstance(result[5], str)
-            assert isinstance(result[6], float)
+        # Test single inserts: u + d + u
+        first, = db.insert_config(configs[0])
+        first_duplicated, = db.insert_config(configs[0])
+        second, = db.insert_config(configs[1])
+        assert first == expected_result[0]
+        assert first_duplicated == expected_result[0]
+        assert second == expected_result[1]
 
-        # Check data in event table
-        event_data, = conn.execute(select(db.event).where(db.event.c.id == 1))
-        assert event_data == EXPECTED_EVENT
-        assert isinstance(event_data[0], int)
-        assert isinstance(event_data[1], int)
-        assert isinstance(event_data[2], str)
-        assert isinstance(event_data[3], float)
-        assert isinstance(event_data[4], float)
-        assert isinstance(event_data[5], float)
-        assert isinstance(event_data[6], int)
-
-        # Check data in hit table
-        hit_data = list(
-            conn.execute(select(db.hit).where(db.hit.c.fk_event == 1))
+        # Test batch inserts: [u, d, u] + u
+        third, third_duplicated, fourth = db.insert_config(
+            [configs[2], configs[2], configs[3]]
         )
-        assert len(hit_data) == EXPECTED_EVENT[-1]
-        assert hit_data[-1] == EXPECTED_HIT
-        assert isinstance(hit_data[-1][0], int)
-        assert isinstance(hit_data[-1][1], int)
-        assert isinstance(hit_data[-1][2], int)
-        assert isinstance(hit_data[-1][3], float)
-        assert isinstance(hit_data[-1][4], float)
-        assert isinstance(hit_data[-1][5], float)
-        assert isinstance(hit_data[-1][6], float)
+        fifth, = db.insert_config(configs[4])
+        assert third == expected_result[2]
+        assert third_duplicated == third
+        assert fourth == expected_result[3]
+        assert fifth == expected_result[4]
+    finally:
+        db.drop()
 
     return None
-
-
-def test_fill_existing_database(make_mock_database: Database) -> None:
-    """
-    Ensure that a filled database is properly loaded
-    """
-    _source = make_sources("mock_source.txt", MOCK_SOURCE_DATA["10-16-800"])
-    source = next(_source)
-
-    mock_db = make_mock_database
-    mock_db.fill(source)
-    db = Database(mock_db.engine.url.database)
-
-    with db.engine.connect() as conn:
-
-        # Check data in config table
-        config_data, = conn.execute(select(db.config))
-        assert config_data == EXPECTED_CONFIG
-        assert isinstance(config_data[0], int)
-        assert isinstance(config_data[1], int)
-        assert isinstance(config_data[2], int)
-        assert isinstance(config_data[3], int)
-        assert isinstance(config_data[4], int)
-        assert isinstance(config_data[5], float)
-        assert isinstance(config_data[6], float)
-        assert isinstance(config_data[7], float)
-        assert isinstance(config_data[8], float)
-
-        # Check data in plane table
-        planes_data = conn.execute(select(db.plane))
-
-        for idx, result in enumerate(planes_data):
-            assert EXPECTED_PLANE[idx] == result
-            assert isinstance(result[0], int)
-            assert isinstance(result[1], float)
-            assert isinstance(result[2], float)
-            assert isinstance(result[3], float)
-            assert isinstance(result[4], float)
-            assert isinstance(result[5], str)
-            assert isinstance(result[6], float)
-
-        # Check data in event table
-        event_data, = conn.execute(select(db.event).where(db.event.c.id == 1))
-        assert event_data == EXPECTED_EVENT
-        assert isinstance(event_data[0], int)
-        assert isinstance(event_data[1], int)
-        assert isinstance(event_data[2], str)
-        assert isinstance(event_data[3], float)
-        assert isinstance(event_data[4], float)
-        assert isinstance(event_data[5], float)
-        assert isinstance(event_data[6], int)
-
-        # Check data in hit table
-        hit_data = list(
-            conn.execute(select(db.hit).where(db.hit.c.fk_event == 1))
-        )
-        assert len(hit_data) == EXPECTED_EVENT[-1]
-        assert hit_data[-1] == EXPECTED_HIT
-        assert isinstance(hit_data[-1][0], int)
-        assert isinstance(hit_data[-1][1], int)
-        assert isinstance(hit_data[-1][2], int)
-        assert isinstance(hit_data[-1][3], float)
-        assert isinstance(hit_data[-1][4], float)
-        assert isinstance(hit_data[-1][5], float)
-        assert isinstance(hit_data[-1][6], float)
-
-    return None
-
-
-def test_plane_uniqueness(make_mock_database: Database) -> None:
-
-    db = make_mock_database
-
-    planes = [
-        (None, 0, 0, 0, 0, "0", 0),
-        (None, 1, 0, 0, 0, "0", 0),
-        (None, 2, 0, 0, 0, "0", 0),
-        (None, 3, 0, 0, 0, "0", 0),
-        (None, 4, 0, 0, 0, "0", 0),
-        (None, 5, 0, 0, 0, "0", 0)
-    ]
-
-    expected_plane_data = [
-        (1, 0, 0, 0, 0, "0", 0),
-        (2, 1, 0, 0, 0, "0", 0),
-        (3, 2, 0, 0, 0, "0", 0),
-        (4, 3, 0, 0, 0, "0", 0),
-        (5, 4, 0, 0, 0, "0", 0)
-    ]
-
-    # Test single inserts: u(nique) + d(uplicate) + u
-    first, = db.insert_plane(planes[0])
-    second, = db.insert_plane(planes[0])
-    third, = db.insert_plane(planes[1])
-    assert first == expected_plane_data[0]
-    assert second == first
-    assert third == expected_plane_data[1]
-
-    # Test batch insert: [u, d, u] + u
-    fourth = db.insert_plane([planes[2], planes[2], planes[3]])
-    fifth, = db.insert_plane(planes[4])
-    assert fourth[0] == expected_plane_data[2]
-    assert fourth[1] == expected_plane_data[2]
-    assert fourth[2] == expected_plane_data[3]
-    assert fifth == expected_plane_data[4]
-
-    return None
-
-
-def test_config_uniqueness(make_mock_database: Database) -> None:
-
-    db = make_mock_database
-
-    planes = [(None, 0, 0, 0, 0, "0", 0), (None, 1, 0, 0, 0, "0", 0)]
-    db.insert_plane(planes)
-
-    configs = [
-        (None, 1, 1, 1, 1, 0, 0, 0, 0),
-        (None, 1, 1, 1, 2, 0, 0, 0, 0),
-        (None, 1, 1, 2, 1, 0, 0, 0, 0),
-        (None, 1, 2, 1, 1, 0, 0, 0, 0),
-        (None, 2, 1, 1, 1, 0, 0, 0, 0)
-    ]
-
-    expected_result = [
-        (1, 1, 1, 1, 1, 0, 0, 0, 0),
-        (2, 1, 1, 1, 2, 0, 0, 0, 0),
-        (3, 1, 1, 2, 1, 0, 0, 0, 0),
-        (4, 1, 2, 1, 1, 0, 0, 0, 0),
-        (5, 2, 1, 1, 1, 0, 0, 0, 0)
-
-    ]
-
-    # Test single inserts: u + d + u
-    first, = db.insert_config(configs[0])
-    first_duplicated, = db.insert_config(configs[0])
-    second, = db.insert_config(configs[1])
-    assert first == expected_result[0]
-    assert first_duplicated == expected_result[0]
-    assert second == expected_result[1]
-
-    # Test batch inserts: [u, d, u] + u
-    third, third_duplicated, fourth = db.insert_config(
-        [configs[2], configs[2], configs[3]]
-    )
-    fifth, = db.insert_config(configs[4])
-    assert third == expected_result[2]
-    assert third_duplicated == third
-    assert fourth == expected_result[3]
-    assert fifth == expected_result[4]
-
-    return None
-
-
-def test_mingo():
-
-    dbgen = make_mock_mingo()
-    db = next(dbgen)
-
-    id = db.get_plane_id(999, 999, 22, 0, "0", 0)
-
-    assert id == 1


### PR DESCRIPTION
+ Add Iterable input type to fill as replacement for batch_fill
+ Directories used as input for fill can now contain non-data-files
+ Set .txt and .csv as valid extensions for data-files
+ Delete create_engine test since it wasn't implemented
+ Test fill and load functionality with every possible input type
+ Prefix Database's private methods with _
+ Reorganize Database's methods